### PR TITLE
Fix #33: Round split amount to exactly 2 decimal places

### DIFF
--- a/splitsmart/lib/screens/home_screen.dart
+++ b/splitsmart/lib/screens/home_screen.dart
@@ -86,10 +86,14 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       _totalAmount = amount ?? 0.0;
       _numberOfPeople = people ?? 1;
       
-      double totalWithTip =
-        _totalAmount + (_totalAmount * _tipPercentage / 100);
+      double totalWithTip = _totalAmount + (_totalAmount * _tipPercentage / 100);
       
-      _perPersonAmount = totalWithTip / _numberOfPeople;
+      // Calculate per person
+      double perPerson = totalWithTip / _numberOfPeople;
+      
+      // Round to exactly 2 decimal places
+      _perPersonAmount = double.parse(perPerson.toStringAsFixed(2));
+      
       _showResult = true;
     });
   }


### PR DESCRIPTION
### Problem
Split amounts were showing excessive decimal values (e.g., ₹33.333333).

### Changes Made
- Fixed rounding logic in `_calculateSplit()` function
- Rounded per-person amount using `toStringAsFixed(2)`
- Ensured all displayed values show exactly 2 decimal places

### Testing
Tested on emulator with:
- 100 ÷ 3 → ₹33.33
- 1000 ÷ 7 → ₹142.86
- Various tip percentages
- Edge cases (invalid input, zero values)

### Result
All amounts now display exactly two decimal places with accurate calculations.

